### PR TITLE
Enhances payload version handling and standardizes resource naming

### DIFF
--- a/app/lambdas/validate_draft_complete_schema_py/validate_draft_complete_schema.py
+++ b/app/lambdas/validate_draft_complete_schema_py/validate_draft_complete_schema.py
@@ -115,12 +115,14 @@ def handler(event, context) -> Dict[str, bool]:
     :return:
     """
     # Get the event data
-    payload_version = event.get("payloadVersion", None)
-    if payload_version is None:
-        payload_version = environ[DEFAULT_PAYLOAD_VERSION_ENV_VAR]
+    payload_version = event.get("payloadVersion")
     payload_data = event.get('data')
     workflow_run_id = event.get("workflowRunId", "")
     comment_error = event.get("addCommentOnError", False)
+
+    # Set payload version if not defined
+    if payload_version is None:
+        payload_version = environ[DEFAULT_PAYLOAD_VERSION_ENV_VAR]
 
     # Get the SSM parameters
     schema_registry = get_ssm_parameter_value(environ[SSM_REGISTRY_NAME_ENV_VAR])

--- a/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
+++ b/app/step-functions-templates/populate_draft_data_sfn_template.asl.json
@@ -21,7 +21,7 @@
       "Arguments": {
         "FunctionName": "${__validate_draft_complete_schema_lambda_function_arn__}",
         "Payload": {
-          "payloadVersion": "{% $payload.version %}",
+          "payloadVersion": "{% $payload.version ? $payload.version : null %}",
           "data": "{% $data %}"
         }
       },

--- a/app/step-functions-templates/validate_draft_data_and_put_ready_event_sfn_template.asl.json
+++ b/app/step-functions-templates/validate_draft_data_and_put_ready_event_sfn_template.asl.json
@@ -21,7 +21,7 @@
       "Arguments": {
         "FunctionName": "${__validate_draft_complete_schema_lambda_function_arn__}",
         "Payload": {
-          "payloadVersion": "{% $payload.version %}",
+          "payloadVersion": "{% $payload.version ? $payload.version : null %}",
           "data": "{% $payloadData %}",
           "workflowRunId": "{% $workflowRunId %}",
           "addCommentOnError": true

--- a/infrastructure/stage/event-rules/index.ts
+++ b/infrastructure/stage/event-rules/index.ts
@@ -73,7 +73,7 @@ function buildWorkflowManagerReadyEventPattern(): EventPattern {
 
 function buildEventRule(scope: Construct, props: EventBridgeRuleProps): Rule {
   return new events.Rule(scope, props.ruleName, {
-    ruleName: `${STACK_PREFIX}-${props.ruleName}`,
+    ruleName: `${STACK_PREFIX}--${props.ruleName}`,
     eventPattern: props.eventPattern,
     eventBus: props.eventBus,
   });

--- a/infrastructure/stage/lambda/index.ts
+++ b/infrastructure/stage/lambda/index.ts
@@ -7,6 +7,7 @@ import {
 } from './interfaces';
 import { PythonUvFunction } from '@orcabus/platform-cdk-constructs/lambda';
 import {
+  DEFAULT_PAYLOAD_VERSION,
   LAMBDA_DIR,
   SCHEMA_REGISTRY_NAME,
   SSM_PARAMETER_PATH_PREFIX,
@@ -126,6 +127,14 @@ function buildLambda(scope: Construct, props: LambdaInput): LambdaObject {
       ],
       true
     );
+
+    /*
+    Special if the lambdaName is 'validateDraftCompleteSchema', we need to add in the ssm parameters
+    to the REGISTRY_NAME and SCHEMA_PATH
+   */
+    if (props.lambdaName === 'validateDraftCompleteSchema') {
+      lambdaFunction.addEnvironment('DEFAULT_PAYLOAD_VERSION', DEFAULT_PAYLOAD_VERSION);
+    }
   }
 
   /* Return the function */

--- a/infrastructure/stage/step-functions/index.ts
+++ b/infrastructure/stage/step-functions/index.ts
@@ -160,7 +160,7 @@ function buildStepFunction(scope: Construct, props: BuildStepFunctionProps): Ste
 
   /* Create the state machine definition substitutions */
   const stateMachine = new sfn.StateMachine(scope, props.stateMachineName, {
-    stateMachineName: `${STACK_PREFIX}-${props.stateMachineName}`,
+    stateMachineName: `${STACK_PREFIX}--${props.stateMachineName}`,
     definitionBody: sfn.DefinitionBody.fromFile(
       path.join(STEP_FUNCTIONS_DIR, sfnNameToSnakeCase + `_sfn_template.asl.json`)
     ),


### PR DESCRIPTION
Improves how the system manages the `payloadVersion` attribute, especially when it's not explicitly provided, and standardizes infrastructure resource naming.

*   **Payload Version Handling:**
    *   Refactors the schema validation lambda to correctly retrieve and default the `payloadVersion` if it's `None`, ensuring consistent processing.
    *   Updates Step Functions definitions to explicitly pass `null` for `payloadVersion` when the input `$payload.version` is not defined, aligning with the lambda's expected input.

*   **Infrastructure Naming:**
    *   Standardizes resource naming by consistently using a double dash as a separator for EventBridge rules and Step Functions state machines, improving clarity and uniformity across the environment.