### PR TITLE
feat: migrate application stacks to GitStack

### DIFF
--- a/infrastructure/stage/stateful-application-stack.ts
+++ b/infrastructure/stage/stateful-application-stack.ts
@@ -3,10 +3,11 @@ import { Construct } from 'constructs';
 import { StatefulApplicationStackConfig } from './interfaces';
 import { buildSchemas } from './event-schemas';
 import { buildSsmParameters } from './ssm';
+import { GitStack } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';
 
 export type StatefulApplicationStackProps = StatefulApplicationStackConfig & cdk.StackProps;
 
-export class StatefulApplicationStack extends cdk.Stack {
+export class StatefulApplicationStack extends GitStack {
   constructor(scope: Construct, id: string, props: StatefulApplicationStackProps) {
     super(scope, id, props);
 

--- a/infrastructure/stage/stateless-application-stack.ts
+++ b/infrastructure/stage/stateless-application-stack.ts
@@ -7,10 +7,11 @@ import { StatelessApplicationStackConfig } from './interfaces';
 import { buildAllEventRules } from './event-rules';
 import { buildAllEventBridgeTargets } from './event-targets';
 import { StageName } from '@orcabus/platform-cdk-constructs/shared-config/accounts';
+import { GitStack } from '@orcabus/platform-cdk-constructs/deployment-stack-pipeline';
 
 export type StatelessApplicationStackProps = cdk.StackProps & StatelessApplicationStackConfig;
 
-export class StatelessApplicationStack extends cdk.Stack {
+export class StatelessApplicationStack extends GitStack {
   public readonly stageName: StageName;
 
   constructor(scope: Construct, id: string, props: StatelessApplicationStackProps) {


### PR DESCRIPTION
Extend both StatelessApplicationStack and StatefulApplicationStack from GitStack instead of cdk.Stack.

This adds a GitCommitId CloudFormation output to each deployed stack, enabling tracking of which commit is currently deployed in each environment.

## Changes
- `infrastructure/stage/stateless-application-stack.ts`: extends GitStack
- `infrastructure/stage/stateful-application-stack.ts`: extends GitStack